### PR TITLE
Process all images with CLIP

### DIFF
--- a/run_clip.py
+++ b/run_clip.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import torch
 import clip
 from PIL import Image
@@ -9,10 +10,10 @@ def main():
         description="Run CLIP on an image with text prompts"
     )
     parser.add_argument(
-        "--image",
+        "--image_dir",
         type=str,
-        default="CLIP.png",
-        help="path to the image to analyze",
+        default="images",
+        help="directory containing images to analyze",
     )
     parser.add_argument(
         "--model",
@@ -23,23 +24,32 @@ def main():
     parser.add_argument(
         "--prompts",
         nargs="+",
-        default=["a diagram", "a dog", "a cat"],
-        help="text prompts to compare with the image",
+        default=["table", "chart", "logo", "architecture"],
+        help="text prompts to compare with the images",
     )
     args = parser.parse_args()
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model, preprocess = clip.load(args.model, device=device)
 
-    image = preprocess(Image.open(args.image)).unsqueeze(0).to(device)
     text = clip.tokenize(args.prompts).to(device)
 
-    with torch.no_grad():
-        logits_per_image, _ = model(image, text)
-        probs = logits_per_image.softmax(dim=-1).cpu().numpy()
+    for img_file in sorted(os.listdir(args.image_dir)):
+        img_path = os.path.join(args.image_dir, img_file)
+        try:
+            image = preprocess(Image.open(img_path)).unsqueeze(0).to(device)
+        except Exception as e:
+            print(f"Skipping {img_file}: {e}")
+            continue
 
-    for label, prob in zip(args.prompts, probs[0]):
-        print(f"{label}: {prob:.4f}")
+        with torch.no_grad():
+            logits_per_image, _ = model(image, text)
+            probs = logits_per_image.softmax(dim=-1).cpu().numpy()
+
+        print(f"Results for {img_file}:")
+        for label, prob in zip(args.prompts, probs[0]):
+            print(f"  {label}: {prob:.4f}")
+        print()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- run CLIP across all images in a directory
- add default categories `table`, `chart`, `logo`, `architecture`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68551fec7834832281fd6b64438068c9